### PR TITLE
Fix compiler warnings. Fix typo in README.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-O2
+CFLAGS=-O2 -Wall
 
 LIBS=-lX11
 OBJ=main.o xeb_handler.o

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # xeventbind
-A small utillity that runs your executable/script when interesting X11 events are fired
+A small utility that runs your executable/script when interesting X11 events are fired.
 
 ## Compilation
 Requires xlib

--- a/main.c
+++ b/main.c
@@ -86,7 +86,7 @@ int handle_callback(xeb_event_type event, void *data) {
             exit(EXIT_FAILURE);
             break;
         case 0: // Child
-            err = execlp(args->script_path, NULL);
+            err = execlp(args->script_path, args->script_path, NULL);
             if (err == -1) {
                 perror("Failed to open callback script\n");
                 exit(EXIT_FAILURE);


### PR DESCRIPTION
Learned about usage of function causing the warning on this SO: https://stackoverflow.com/questions/21558937/i-do-not-understand-how-execlp-works-in-linux

Verified behavior by running:

```
./xeventbind resolution /bin/ls
```

And then changed the resolution of my computer and saw that ls output was provided by program.