### PR TITLE
Makefile: Added install/uninstall recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,22 @@ CFLAGS=-O2 -Wall
 LIBS=-lX11
 OBJ=main.o xeb_handler.o
 
+PREFIX=/usr/local
+
 .PHONY: all clean
 all: xeventbind
 
 xeventbind: $(OBJ)
-	$(CC) -o $@ $^ $(LIBS) $(CFLAGS)	
+	$(CC) -o $@ $^ $(LIBS) $(CFLAGS)
 
 %.o: %.c
 	$(CC) -c -o $@ $< $(CFLAGS)
+
+install: xeventbind
+	install -m 755 $< $(PREFIX)/bin
+
+uninstall:
+	rm $(PREFIX)/bin/xeventbind
 
 clean:
 	rm -f xeventbind *.o


### PR DESCRIPTION
I'm just adding some quality of life stuff, there's a few tools I install directly from github, and xeventbind is the only one where I can't just run the canonical `make install PREFIX=...` during an unattended install, thanks!
